### PR TITLE
Rename http://schema.org to https://schema.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ These are:
     <tr><th>geo</th><td>http://www.w3.org/2003/01/geo/wgs84_pos#</td></tr>
     <tr><th>rdf</th><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td></tr>
     <tr><th>rdfs</th><td>http://www.w3.org/2000/01/rdf-schema#</td></tr>
-    <tr><th>schema</th><td>http://schema.org/</td></tr>
+    <tr><th>schema</th><td>https://schema.org/</td></tr>
     <tr><th>vcard</th><td>http://www.w3.org/2006/vcard/ns#</td></tr>
     <tr><th>vocab</th><td>http://rdf.data-vocabulary.org/#</td></tr>
     <tr><th>xsd</th><td>http://www.w3.org/2001/XMLSchema#</td></tr>

--- a/include/zotonic_rdf.hrl
+++ b/include/zotonic_rdf.hrl
@@ -7,7 +7,7 @@
 -define(NS_GEO, <<"http://www.w3.org/2003/01/geo/wgs84_pos#">>).
 -define(NS_VCARD, <<"http://www.w3.org/2006/vcard/ns#">>).
 -define(NS_ACL, <<"http://www.w3.org/ns/auth/acl#">>).
--define(NS_SCHEMA_ORG, <<"http://schema.org/">>).
+-define(NS_SCHEMA_ORG, <<"https://schema.org/">>).
 -define(NS_FOAF, <<"http://xmlns.com/foaf/0.1/">>).
 -define(NS_DC, <<"http://purl.org/dc/elements/1.1/">>).
 -define(NS_DCTERMS, <<"http://purl.org/dc/terms/">>).

--- a/src/rdf_triples.erl
+++ b/src/rdf_triples.erl
@@ -146,7 +146,7 @@ ns_expand(Pred, Ns) ->
          Ns :: #{ binary() := binary() }.
 ns_compact(Pred, Ns) ->
     Next = maps:iterator(Ns),
-    ns_compact_1(Pred, maps:next(Next)).
+    ns_compact_1(ns_normalize(Pred), maps:next(Next)).
 
 ns_compact_1(Pred, none) ->
     Pred;
@@ -158,6 +158,12 @@ ns_compact_1(Pred, {Ns, Uri, Next}) ->
             ns_compact_1(Pred, maps:next(Next))
     end.
 
+%% @doc Normalize namespaces that are known to have been renamed.
+-spec ns_normalize(Pred) -> NewPred
+    when Pred :: binary(),
+         NewPred ::binary().
+ns_normalize(<<"http://schema.org/", P/binary>>) -> <<"https://schema.org", P/binary>>;
+ns_normalize(Pred) -> Pred.
 
 
 %% @doc Combine a list of triples into a collection of JSON-LD (alike) documents.


### PR DESCRIPTION
With schema.org version 12.0 the namespace has been renamed from http://schema.org to https://schema.org

See https://schema.org/docs/releases.html

> [PR #2814](https://github.com/schemaorg/schemaorg/pull/2814): Completed process of moving Schema.org to https. This step included the move to https of vocabulary term definitions and consequent change to https of the canonical URI displayed under the term pages [more...] tag. The web site will continue to respond to both http and https URLs. Download files will continue to support both protocols.

This code change lets `ns_compact` accept both the `http:` and the `https:` variant of the schema.org namespace.